### PR TITLE
Autolås kan justeres med timer

### DIFF
--- a/.homeycompose/drivers/settings/auto_lock_delay.json
+++ b/.homeycompose/drivers/settings/auto_lock_delay.json
@@ -1,0 +1,17 @@
+{
+  "id": "auto_lock_delay",
+  "type": "number",
+  "label": {
+    "en": "Auto Lock Delay (seconds)",
+    "no": "Autolås forsinkelse (sekunder)",
+    "sv": "Autolås fördröjning (sekunder)"
+  },
+  "hint": {
+    "en": "Time in seconds before the door automatically locks after being closed. Setting this value > 0 will disable the lock's internal auto-lock function. Set to 0 to disable this feature.",
+    "no": "Tid i sekunder før døren låses automatisk etter at den er lukket. Hvis denne verdien settes > 0, deaktiveres låsens interne autolåsfunksjon. Sett til 0 for å deaktivere denne funksjonen.",
+    "sv": "Tid i sekunder innan dörren låses automatiskt efter att den stängts. Om detta värde sätts > 0 inaktiveras låsets interna autolåsfunktion. Sätt till 0 för att inaktivera denna funktion."
+  },
+  "value": 0,
+  "min": 0,
+  "max": 3600
+}

--- a/.homeycompose/flow/actions/set_auto_lock_delay.json
+++ b/.homeycompose/flow/actions/set_auto_lock_delay.json
@@ -1,0 +1,28 @@
+{
+    "id": "set_auto_lock_delay",
+    "title": {
+        "en": "Set auto lock delay",
+        "no": "Sett autolås forsinkelse"
+    },
+    "titleFormatted": {
+        "en": "Set auto lock delay to [[delay]] seconds",
+        "no": "Sett autolås forsinkelse til [[delay]] sekunder"
+    },
+    "args": [
+        {
+            "name": "device",
+            "type": "device",
+            "filter": "driver_id=IDlock150"
+        },
+        {
+            "name": "delay",
+            "type": "number",
+            "min": 0,
+            "max": 3600,
+            "title": {
+                "en": "Delay (seconds)",
+                "no": "Forsinkelse (sekunder)"
+            }
+        }
+    ]
+}

--- a/app.js
+++ b/app.js
@@ -39,6 +39,10 @@ class IDLock extends Homey.App {
     this.homey.flow.getActionCard('update_lockstatus').registerRunListener((args, state) => {
       return args.device.updateLockStatusActionRunListener(args, state)
     })
+
+    this.homey.flow.getActionCard('set_auto_lock_delay').registerRunListener((args, state) => {
+      return args.device.setAutoLockDelayAction(args)
+    })
   }
 
   onTypeWhoMatchTrigger (args, state) {

--- a/drivers/IDlock150/driver.settings.compose.json
+++ b/drivers/IDlock150/driver.settings.compose.json
@@ -4,6 +4,10 @@
     "id": "Doorlock_mode"
   },
   {
+    "$extends": "auto_lock_delay",
+    "id": "auto_lock_delay"
+  },
+  {
     "$extends": "Doorlock_Hinge_Position",
     "id": "Doorlock_Hinge_Position"
   },


### PR DESCRIPTION
Fant ingen dokumentasjon på at timer til autolås eksponeres til zwave, men her er en mer eller mindre elegant hack som oppnår det samme: 
Homey deaktiverer autolås når man velger egendefinert autolås tid og håndterer selv autolåsen ved å sende låskommando etter angitt tid.